### PR TITLE
Support for rustc nightly 2014-06-29

### DIFF
--- a/src/al.rs
+++ b/src/al.rs
@@ -136,7 +136,7 @@ pub mod ffi {
         pub fn alEnable(capability: ALenum);
         pub fn alDisable(capability: ALenum);
         pub fn alIsEnabled(capability: ALenum) -> ALboolean;
-        pub fn alGetString(param: ALenum) -> *ALchar;
+        pub fn alGetString(param: ALenum) -> *const ALchar;
         pub fn alGetBooleanv(param: ALenum, data: *mut ALboolean);
         pub fn alGetIntegerv(param: ALenum, data: *mut ALint);
         pub fn alGetFloatv(param: ALenum, data: *mut ALfloat);
@@ -146,16 +146,16 @@ pub mod ffi {
         pub fn alGetFloat(param: ALenum) -> ALfloat;
         pub fn alGetDouble(param: ALenum) -> ALdouble;
         pub fn alGetError() -> ALenum;
-        pub fn alIsExtensionPresent(extname: *ALchar) -> ALboolean;
-        pub fn alGetProcAddress(fname: *ALchar) -> Option<extern "C" fn()>;
-        pub fn alGetEnumValue(ename: *ALchar) -> ALenum;
+        pub fn alIsExtensionPresent(extname: *const ALchar) -> ALboolean;
+        pub fn alGetProcAddress(fname: *const ALchar) -> Option<extern "C" fn()>;
+        pub fn alGetEnumValue(ename: *const ALchar) -> ALenum;
 
         pub fn alListenerf(param: ALenum, value: ALfloat);
         pub fn alListener3f(param: ALenum, value1: ALfloat, value2: ALfloat, value3: ALfloat);
-        pub fn alListenerfv(param: ALenum, values: *ALfloat);
+        pub fn alListenerfv(param: ALenum, values: *const ALfloat);
         pub fn alListeneri(param: ALenum, value: ALint);
         pub fn alListener3i(param: ALenum, value1: ALint, value2: ALint, value3: ALint);
-        pub fn alListeneriv(param: ALenum, values: *ALint);
+        pub fn alListeneriv(param: ALenum, values: *const ALint);
         pub fn alGetListenerf(param: ALenum, value: *mut ALfloat);
         pub fn alGetListener3f(param: ALenum, value1: *mut ALfloat, value2: *mut ALfloat, value3: *mut ALfloat);
         pub fn alGetListenerfv(param: ALenum, values: *mut ALfloat);
@@ -163,40 +163,40 @@ pub mod ffi {
         pub fn alGetListener3i(param: ALenum, value1: *mut ALint, value2: *mut ALint, value3: *mut ALint);
         pub fn alGetListeneriv(param: ALenum, values: *mut ALint);
         pub fn alGenSources(n: ALsizei, sources: *mut ALuint);
-        pub fn alDeleteSources(n: ALsizei, sources: *ALuint);
+        pub fn alDeleteSources(n: ALsizei, sources: *const ALuint);
         pub fn alIsSource(sid: ALuint) -> ALboolean;
         pub fn alSourcef(sid: ALuint, param: ALenum, value: ALfloat);
         pub fn alSource3f(sid: ALuint, param: ALenum, value1: ALfloat, value2: ALfloat, value3: ALfloat);
-        pub fn alSourcefv(sid: ALuint, param: ALenum, values: *ALfloat);
+        pub fn alSourcefv(sid: ALuint, param: ALenum, values: *const ALfloat);
         pub fn alSourcei(sid: ALuint, param: ALenum, value: ALint);
         pub fn alSource3i(sid: ALuint, param: ALenum, value1: ALint, value2: ALint, value3: ALint);
-        pub fn alSourceiv(sid: ALuint, param: ALenum, values: *ALint);
+        pub fn alSourceiv(sid: ALuint, param: ALenum, values: *const ALint);
         pub fn alGetSourcef(sid: ALuint, param: ALenum, value: *mut ALfloat);
         pub fn alGetSource3f(sid: ALuint, param: ALenum, value1: *mut ALfloat, value2: *mut ALfloat, value3: *mut ALfloat);
         pub fn alGetSourcefv(sid: ALuint, param: ALenum, values: *mut ALfloat);
         pub fn alGetSourcei(sid: ALuint,  param: ALenum, value: *mut ALint);
         pub fn alGetSource3i(sid: ALuint, param: ALenum, value1: *mut ALint, value2: *mut ALint, value3: *mut ALint);
         pub fn alGetSourceiv(sid: ALuint,  param: ALenum, values: *mut ALint);
-        pub fn alSourcePlayv(ns: ALsizei, sids: *ALuint);
-        pub fn alSourceStopv(ns: ALsizei, sids: *ALuint);
-        pub fn alSourceRewindv(ns: ALsizei, sids: *ALuint);
-        pub fn alSourcePausev(ns: ALsizei, sids: *ALuint);
+        pub fn alSourcePlayv(ns: ALsizei, sids: *const ALuint);
+        pub fn alSourceStopv(ns: ALsizei, sids: *const ALuint);
+        pub fn alSourceRewindv(ns: ALsizei, sids: *const ALuint);
+        pub fn alSourcePausev(ns: ALsizei, sids: *const ALuint);
         pub fn alSourcePlay(sid: ALuint);
         pub fn alSourceStop(sid: ALuint);
         pub fn alSourceRewind(sid: ALuint);
         pub fn alSourcePause(sid: ALuint);
-        pub fn alSourceQueueBuffers(sid: ALuint, numEntries: ALsizei, bids: *ALuint);
-        pub fn alSourceUnqueueBuffers(sid: ALuint, numEntries: ALsizei, bids: *ALuint);
+        pub fn alSourceQueueBuffers(sid: ALuint, numEntries: ALsizei, bids: *const ALuint);
+        pub fn alSourceUnqueueBuffers(sid: ALuint, numEntries: ALsizei, bids: *mut ALuint);
         pub fn alGenBuffers(n: ALsizei, buffers: *mut ALuint);
-        pub fn alDeleteBuffers(n: ALsizei, buffers: *ALuint);
+        pub fn alDeleteBuffers(n: ALsizei, buffers: *const ALuint);
         pub fn alIsBuffer(bid: ALuint) -> ALboolean;
-        pub fn alBufferData(bid: ALuint, format: ALenum, data: *ALvoid, size: ALsizei, freq: ALsizei);
+        pub fn alBufferData(bid: ALuint, format: ALenum, data: *const ALvoid, size: ALsizei, freq: ALsizei);
         pub fn alBufferf(bid: ALuint, param: ALenum, value: ALfloat);
         pub fn alBuffer3f(bid: ALuint, param: ALenum, value1: ALfloat, value2: ALfloat, value3: ALfloat);
-        pub fn alBufferfv(bid: ALuint, param: ALenum, values: *ALfloat);
+        pub fn alBufferfv(bid: ALuint, param: ALenum, values: *const ALfloat);
         pub fn alBufferi(bid: ALuint, param: ALenum, value: ALint);
         pub fn alBuffer3i(bid: ALuint, param: ALenum, value1: ALint, value2: ALint, value3: ALint);
-        pub fn alBufferiv(bid: ALuint, param: ALenum, values: *ALint);
+        pub fn alBufferiv(bid: ALuint, param: ALenum, values: *const ALint);
         pub fn alGetBufferf(bid: ALuint, param: ALenum, value: *mut ALfloat);
         pub fn alGetBuffer3f(bid: ALuint, param: ALenum, value1: *mut ALfloat, value2: *mut ALfloat, value3: *mut ALfloat);
         pub fn alGetBufferfv(bid: ALuint, param: ALenum, values: *mut ALfloat);
@@ -250,21 +250,21 @@ pub fn set_speed_of_sound(value: ALfloat) {
     unsafe { ffi::alSpeedOfSound(value); }
 }
 
-#[repr(int)]
+#[repr(i32)]
 pub enum DistanceModel {
     InverseDistance             = ffi::INVERSE_DISTANCE,
     InverseDistanceClamped      = ffi::INVERSE_DISTANCE_CLAMPED,
     LinearDistance              = ffi::LINEAR_DISTANCE,
     LinearDistanceClamped       = ffi::LINEAR_DISTANCE_CLAMPED,
     ExponentDistance            = ffi::EXPONENT_DISTANCE,
-    ExponentDistanceClamped     = ffi::EXPONENT_DISTANCE_CLAMPED,
+    ExponentDistanceClamped     = ffi::EXPONENT_DISTANCE_CLAMPED
 }
 
 pub fn get_distance_model() -> Option<DistanceModel> {
     unsafe {
         match ffi::alGetInteger(ffi::DISTANCE_MODEL) {
             ffi::NONE => None,
-            model => Some(mem::transmute(model as int)),
+            model => Some(mem::transmute(model)),
         }
     }
 }
@@ -411,7 +411,7 @@ pub fn delete_sources(sources: Vec<Source>) {
 }
 
 #[deriving(PartialEq)]
-#[repr(int)]
+#[repr(i32)]
 pub enum SourceType {
     Static          = ffi::STATIC,
     Streaming       = ffi::STREAMING,
@@ -504,13 +504,13 @@ impl Source {
     }
 
     /// Remove a single buffer from the queue.
-    pub fn unqueue_buffer(&self, buffer: &Buffer) {
-        unsafe { ffi::alSourceUnqueueBuffers(self.id, 1, &buffer.id); }
+    pub fn unqueue_buffer(&self, buffer: &mut Buffer) {
+        unsafe { ffi::alSourceUnqueueBuffers(self.id, 1, &mut buffer.id); }
     }
 
     /// Remove a set of buffers from the queue.
-    pub fn unqueue_buffers(&self, buffers: &[Buffer]) {
-        unsafe { ffi::alSourceUnqueueBuffers(self.id, buffers.len() as ALsizei, &buffers[0].id); }
+    pub fn unqueue_buffers(&self, buffers: &mut [Buffer]) {
+        unsafe { ffi::alSourceUnqueueBuffers(self.id, buffers.len() as ALsizei, &mut buffers[0].id); }
     }
 
     // The number of buffers queued on this source.
@@ -667,7 +667,7 @@ impl Source {
 
     // The source type.
     pub fn get_type(&self) -> SourceType {
-        unsafe { mem::transmute(get_source!(i, ffi::SOURCE_TYPE) as int) }
+        unsafe { mem::transmute(get_source!(i, ffi::SOURCE_TYPE) as i32) }
     }
 
     /// Set the source type.
@@ -738,19 +738,19 @@ impl Drop for Source {
 }
 
 pub fn play_sources(sources: &[Source]) {
-    unsafe { ffi::alSourcePlayv(sources.len() as ALsizei, sources.as_ptr() as *ALuint); }
+    unsafe { ffi::alSourcePlayv(sources.len() as ALsizei, sources.as_ptr() as *const ALuint); }
 }
 
 pub fn stop_sources(sources: &[Source]) {
-    unsafe { ffi::alSourceStopv(sources.len() as ALsizei, sources.as_ptr() as *ALuint); }
+    unsafe { ffi::alSourceStopv(sources.len() as ALsizei, sources.as_ptr() as *const ALuint); }
 }
 
 pub fn rewind_sources(sources: &[Source]) {
-    unsafe { ffi::alSourceRewindv(sources.len() as ALsizei, sources.as_ptr() as *ALuint); }
+    unsafe { ffi::alSourceRewindv(sources.len() as ALsizei, sources.as_ptr() as *const ALuint); }
 }
 
 pub fn pause_sources(sources: &[Source]) {
-    unsafe { ffi::alSourcePausev(sources.len() as ALsizei, sources.as_ptr() as *ALuint); }
+    unsafe { ffi::alSourcePausev(sources.len() as ALsizei, sources.as_ptr() as *const ALuint); }
 }
 
 /// A reference to a buffer object
@@ -801,7 +801,7 @@ impl Buffer {
     /// Fill the buffer with PCM audio data.
     pub unsafe fn buffer_data<T>(&self, format: Format, data: &[T], freq: ALsizei) {
         ffi::alBufferData(
-            self.id, format as ALenum, data.as_ptr() as *ALvoid,
+            self.id, format as ALenum, data.as_ptr() as *const ALvoid,
             (mem::size_of::<T>() * data.len()) as ALsizei,
             freq
         );

--- a/src/alc.rs
+++ b/src/alc.rs
@@ -80,32 +80,32 @@ pub mod ffi {
     pub struct ALCcontext;
 
     extern "C" {
-        pub fn alcCreateContext(device: *ALCdevice, attrlist: *ALCint) -> *ALCcontext;
-        pub fn alcMakeContextCurrent(context: *ALCcontext) -> ALCboolean;
-        pub fn alcProcessContext(context: *ALCcontext);
-        pub fn alcSuspendContext(context: *ALCcontext);
-        pub fn alcDestroyContext(context: *ALCcontext);
-        pub fn alcGetCurrentContext() -> *ALCcontext;
-        pub fn alcGetContextsDevice(context: *ALCcontext) -> *ALCdevice;
+        pub fn alcCreateContext(device: *const ALCdevice, attrlist: *const ALCint) -> *const ALCcontext;
+        pub fn alcMakeContextCurrent(context: *const ALCcontext) -> ALCboolean;
+        pub fn alcProcessContext(context: *const ALCcontext);
+        pub fn alcSuspendContext(context: *const ALCcontext);
+        pub fn alcDestroyContext(context: *const ALCcontext);
+        pub fn alcGetCurrentContext() -> *const ALCcontext;
+        pub fn alcGetContextsDevice(context: *const ALCcontext) -> *const ALCdevice;
 
-        pub fn alcOpenDevice(devicename: *ALCchar) -> *ALCdevice;
-        pub fn alcCloseDevice(device: *ALCdevice) -> ALCboolean;
-        pub fn alcGetError(device: *ALCdevice) -> ALCenum;
-        pub fn alcIsExtensionPresent(device: *ALCdevice, extname: *ALCchar) -> ALCboolean;
-        pub fn alcGetProcAddress(device: *ALCdevice, funcname: *ALCchar) -> Option<extern "C" fn()>;
-        pub fn alcGetEnumValue(device: *ALCdevice, enumname: *ALCchar) -> ALCenum;
-        pub fn alcGetString(device: *ALCdevice, param: ALCenum) -> *ALCchar;
-        pub fn alcGetIntegerv(device: *ALCdevice, param: ALCenum, size: ALCsizei, data: *mut ALCint);
-        pub fn alcCaptureOpenDevice(devicename: *ALCchar, frequency: ALCuint, format: ALCenum, buffersize: ALCsizei) -> *ALCdevice;
-        pub fn alcCaptureCloseDevice(device: *ALCdevice) -> ALCboolean;
-        pub fn alcCaptureStart(device: *ALCdevice);
-        pub fn alcCaptureStop(device: *ALCdevice);
-        pub fn alcCaptureSamples(device: *ALCdevice, buffer: *ALCvoid, samples: ALCsizei);
+        pub fn alcOpenDevice(devicename: *const ALCchar) -> *const ALCdevice;
+        pub fn alcCloseDevice(device: *const ALCdevice) -> ALCboolean;
+        pub fn alcGetError(device: *const ALCdevice) -> ALCenum;
+        pub fn alcIsExtensionPresent(device: *const ALCdevice, extname: *const ALCchar) -> ALCboolean;
+        pub fn alcGetProcAddress(device: *const ALCdevice, funcname: *const ALCchar) -> Option<extern "C" fn()>;
+        pub fn alcGetEnumValue(device: *const ALCdevice, enumname: *const ALCchar) -> ALCenum;
+        pub fn alcGetString(device: *const ALCdevice, param: ALCenum) -> *const ALCchar;
+        pub fn alcGetIntegerv(device: *const ALCdevice, param: ALCenum, size: ALCsizei, data: *mut ALCint);
+        pub fn alcCaptureOpenDevice(devicename: *const ALCchar, frequency: ALCuint, format: ALCenum, buffersize: ALCsizei) -> *const ALCdevice;
+        pub fn alcCaptureCloseDevice(device: *const ALCdevice) -> ALCboolean;
+        pub fn alcCaptureStart(device: *const ALCdevice);
+        pub fn alcCaptureStop(device: *const ALCdevice);
+        pub fn alcCaptureSamples(device: *const ALCdevice, buffer: *const ALCvoid, samples: ALCsizei);
     }
 }
 
 pub struct Context {
-    ptr: *ffi::ALCcontext,
+    ptr: *const ffi::ALCcontext,
 }
 
 // pub fn get_current_context() -> Context {
@@ -143,7 +143,7 @@ impl Drop for Context {
 }
 
 pub struct Device {
-    ptr: *ffi::ALCdevice,
+    ptr: *const ffi::ALCdevice,
 }
 
 impl Device {
@@ -175,7 +175,7 @@ impl Device {
         unsafe { str::raw::from_c_str(ffi::alcGetString(self.ptr, param)) }
     }
 
-    // pub fn GetIntegerv(&self, param: ALCenum, size: ALCsizei, data: *ALCint) {
+    // pub fn GetIntegerv(&self, param: ALCenum, size: ALCsizei, data: *const ALCint) {
     //     unsafe { ffi::alcGetIntegerv(); }
     // }
 
@@ -188,7 +188,7 @@ impl Device {
 }
 
 pub struct CaptureDevice {
-    ptr: *ffi::ALCdevice,
+    ptr: *const ffi::ALCdevice,
 }
 
 impl CaptureDevice {
@@ -214,7 +214,7 @@ impl CaptureDevice {
         unsafe { ffi::alcCaptureStop(self.ptr); }
     }
 
-    // pub fn CaptureSamples(&self, buffer: *ALCvoid, samples: ALCsizei) {
+    // pub fn CaptureSamples(&self, buffer: *const ALCvoid, samples: ALCsizei) {
     //     unsafe { ffi::alcCaptureSamples(); }
     // }
 }


### PR DESCRIPTION
- Changed \* to *const
- Changed enum repr to i32 to fix type mismatch errors
- Also an unrelated change that fixes Source::unqueue_buffer and Source::unqueue_buffers so they handle errors and return results instead of filling buffers
