### PR TITLE
Fix items macro syntax; address warnings

### DIFF
--- a/src/al.rs
+++ b/src/al.rs
@@ -15,7 +15,6 @@
 
 use std::fmt;
 use std::mem;
-use std::string;
 
 pub use self::types::*;
 
@@ -211,19 +210,19 @@ pub mod ffi {
 }
 
 pub fn get_vendor() -> String {
-    unsafe { string::raw::from_buf(ffi::alGetString(ffi::VENDOR) as *const u8) }
+    unsafe { String::from_raw_buf(ffi::alGetString(ffi::VENDOR) as *const u8) }
 }
 
 pub fn get_version() -> String {
-    unsafe { string::raw::from_buf(ffi::alGetString(ffi::VERSION) as *const u8) }
+    unsafe { String::from_raw_buf(ffi::alGetString(ffi::VERSION) as *const u8) }
 }
 
 pub fn get_renderer() -> String {
-    unsafe { string::raw::from_buf(ffi::alGetString(ffi::RENDERER) as *const u8) }
+    unsafe { String::from_raw_buf(ffi::alGetString(ffi::RENDERER) as *const u8) }
 }
 
 pub fn get_extensions() -> String {
-    unsafe { string::raw::from_buf(ffi::alGetString(ffi::EXTENSIONS) as *const u8) }
+    unsafe { String::from_raw_buf(ffi::alGetString(ffi::EXTENSIONS) as *const u8) }
 }
 
 pub fn get_doppler_factor() -> ALfloat {
@@ -250,6 +249,7 @@ pub fn set_speed_of_sound(value: ALfloat) {
     unsafe { ffi::alSpeedOfSound(value); }
 }
 
+#[deriving(Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum DistanceModel {
     InverseDistance             = ffi::INVERSE_DISTANCE,
@@ -279,7 +279,7 @@ pub fn set_distance_model(value: Option<DistanceModel>) {
 }
 
 /// An OpenAL error code
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq, Eq)]
 pub enum Error {
     /// A bad name (ID) was passed to an OpenAL function.
     InvalidName,
@@ -410,7 +410,7 @@ pub fn delete_sources(sources: Vec<Source>) {
     // unsafe { ffi::alDeleteSources(sources.len() as ALsizei, &sources[0].id); }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum SourceType {
     Static          = ffi::STATIC,
@@ -418,7 +418,7 @@ pub enum SourceType {
     Undetermined    = ffi::UNDETERMINED,
 }
 
-macro_rules! get_source(
+macro_rules! get_source{
     ($self_:ident, fv, $param:expr, $n:expr) => ({
         let mut values = [0.0, ..$n];
         ffi::alGetSourcef($self_.id, $param, &mut values[0]);
@@ -434,7 +434,7 @@ macro_rules! get_source(
         ffi::alGetSourcei($self_.id, $param, &mut value);
         value
     });
-)
+}
 
 impl Source {
     /// Generate a single source object.
@@ -776,7 +776,7 @@ pub fn delete_buffers(buffers: Vec<Buffer>) {
     // unsafe { ffi::alDeleteBuffers(buffers.len() as ALsizei, &buffers[0].id); }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq, Eq)]
 pub enum Format {
     FormatMono8         = ffi::FORMAT_MONO8     as int,
     FormatMono16        = ffi::FORMAT_MONO16    as int,

--- a/src/alc.rs
+++ b/src/alc.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::string;
 use std::ptr;
 
 use self::types::*;
@@ -76,8 +75,10 @@ pub mod ffi {
     pub const CAPTURE_DEFAULT_DEVICE_SPECIFIER     : ALCenum = 0x311;
     pub const CAPTURE_SAMPLES                      : ALCenum = 0x312;
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct ALCdevice;
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct ALCcontext;
 
@@ -144,6 +145,7 @@ impl Drop for Context {
     }
 }
 
+#[allow(missing_copy_implementations)]
 pub struct Device {
     ptr: *const ffi::ALCdevice,
 }
@@ -174,7 +176,7 @@ impl Device {
     }
 
     pub fn get_string(&self, param: ALCenum) -> String {
-        unsafe { string::raw::from_buf(ffi::alcGetString(self.ptr, param) as *const u8) }
+        unsafe { String::from_raw_buf(ffi::alcGetString(self.ptr, param) as *const u8) }
     }
 
     // pub fn GetIntegerv(&self, param: ALCenum, size: ALCsizei, data: *const ALCint) {
@@ -189,6 +191,7 @@ impl Device {
     }
 }
 
+#[allow(missing_copy_implementations)]
 pub struct CaptureDevice {
     ptr: *const ffi::ALCdevice,
 }

--- a/src/openal.rs
+++ b/src/openal.rs
@@ -4,7 +4,6 @@
        author = "Brendan Zabarauskas",
        url = "https://github.com/bjz/openal-rs")]
 
-#![comment = "OpenAL 1.1 bindings for Rust."]
 #![crate_type = "lib"]
 
 #![feature(macro_rules)]


### PR DESCRIPTION
Fixes items macro syntax and derives or ignores Copy for types that are eligible.
