### PR TITLE
Correct lifetimes of context creation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alto"
 description = "Idiomatic interface for OpenAL 1.1 and extensions (including EFX)"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Jameson Ernst <jameson@jpernst.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/jpernst/alto.git"

--- a/src/al/mod.rs
+++ b/src/al/mod.rs
@@ -521,13 +521,13 @@ impl<'d> Context<'d> {
 
 
 	/// `alGenSources()`
-	pub fn new_static_source(&self) -> AltoResult<StaticSource> {
+	pub fn new_static_source<'c>(&'c self) -> AltoResult<StaticSource<'d, 'c>> {
 		StaticSource::new(self)
 	}
 
 
 	/// `alGenSources()`
-	pub fn new_streaming_source(&self) -> AltoResult<StreamingSource> {
+	pub fn new_streaming_source<'c>(&'c self) -> AltoResult<StreamingSource<'d, 'c>> {
 		StreamingSource::new(self)
 	}
 


### PR DESCRIPTION
Lifetime elision resulted in wrong lifetime assumption for created contexts. This corrects the issue by explicit specification of lifetimes.