### PR TITLE
Add basic example and copy API usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Idiomatic Rust bindings for [OpenAL 1.1](http://connect.creativelabs.com/openal/) and extensions (including EFX).
+# alto
+
+`alto` provides idiomatic Rust bindings for [OpenAL 1.1](http://connect.creativelabs.com/openal/)
+and extensions (including EFX).
+
+## API Usage
+
+```rust
+let alto = Alto::load_default()?;
+
+for s in alto.enumerate_outputs() {
+    println!("Found device: {}", s.to_str()?);
+}
+
+let device = alto.open(None)?; // Opens the default audio device
+let context = device.new_context(None)?; // Creates a default context
+// The context automatically becomes the current one
+
+// Configure listener
+context.set_position([1.0, 4.0, 5.0]);
+context.set_velocity([2.5, 0.0, 0.0]);
+context.set_orientation(([0.0, 0.0, 1.0], [0.0, 1.0, 0.0]));
+
+let source = context.new_static_source()?;
+
+// Now you can load your samples and store them in a buffer with
+// `context.new_buffer(samples, frequency)`;
+```

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,36 @@
+extern crate alto;
+
+use alto::{Alto, AltoResult};
+
+fn run() -> AltoResult<()> {
+    let alto = Alto::load_default()?;
+
+    for s in alto.enumerate_outputs() {
+        println!("Found device: {}", s.to_str().unwrap());
+    }
+
+    let device = alto.open(None)?; // Opens the default audio device
+    let context = device.new_context(None)?; // Creates a default context
+    // The context automatically becomes the current one
+
+    // Configure listener
+    context.set_position([1.0, 4.0, 5.0])?;
+    context.set_velocity([2.5, 0.0, 0.0])?;
+    context.set_orientation(([0.0, 0.0, 1.0], [0.0, 1.0, 0.0]))?;
+
+    let _source = context.new_static_source()?;
+
+    // Now you can load your samples and store them in a buffer with
+    // `context.new_buffer(samples, frequency)`;
+
+    Ok(())
+}
+
+fn main() {
+    use std::process::exit;
+
+    if let Err(e) = run() {
+        println!("Failed to run basic example: {}", e);
+        exit(1);
+    }
+}


### PR DESCRIPTION
It's nice to see how the API looks like when you visit the Repository, so I think it should go into the README.