### PR TITLE
Implement missing `Drop` for `Capture`

### DIFF
--- a/src/alc.rs
+++ b/src/alc.rs
@@ -817,5 +817,10 @@ impl<F: StandardFrame> PartialEq for Capture<F> {
 }
 impl<F: StandardFrame> Eq for Capture<F> { }
 
+impl<F: StandardFrame> Drop for Capture<F> {
+	fn drop(&mut self) {
+		unsafe { self.alto.0.api.alcCaptureCloseDevice(self.dev); }
+	}
+}
 
 unsafe impl<F: StandardFrame> Send for Capture<F> { }


### PR DESCRIPTION
The fact that the destructor is missing isn't that bad, because we cleanup when `Alto` goes out of scope, but I guess it's nice to not have it leak.