### PR TITLE
add a dynamic feature flag, allowing static linking if desired

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ homepage = "https://www.jpernst.com"
 keywords = ["openal", "al", "sound", "audio"]
 categories = ["multimedia::audio", "api-bindings"]
 
+[features]
+default = ["dynamic"]
+dynamic = ["al-sys/dynamic"]
+
 [dependencies]
 lazy_static = "0.2.1"
 parking_lot = "0.4.4"
-al-sys = { version = "0.6.0", path = "al-sys" }
+al-sys = { version = "0.6.0", path = "al-sys", default-features = false }

--- a/al-sys/Cargo.toml
+++ b/al-sys/Cargo.toml
@@ -10,11 +10,15 @@ homepage = "https://www.jpernst.com"
 keywords = ["openal", "al", "sound", "audio"]
 categories = ["multimedia::audio", "external-ffi-bindings"]
 
+[features]
+default = ["dynamic"]
+dynamic = ["libloading", "rental"]
+
 [build-dependencies]
 pkg-config = "0.3.8"
 
 [dependencies]
-rental = "0.5.0"
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
-libloading = "0.5"
+libloading = { version = "0.5", optional = true }
+rental = { version = "0.5.0", optional = true }

--- a/al-sys/Cargo.toml
+++ b/al-sys/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["multimedia::audio", "external-ffi-bindings"]
 default = ["dynamic"]
 dynamic = ["libloading", "rental"]
 
-[build-dependencies]
-pkg-config = "0.3.8"
-
 [dependencies]
+
+[build-dependencies]
+cmake = "0.1.40"
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
 libloading = { version = "0.5", optional = true }

--- a/al-sys/build.rs
+++ b/al-sys/build.rs
@@ -1,0 +1,96 @@
+extern crate cmake;
+
+use cmake::Config;
+use std::{env, path::PathBuf, process::Command};
+
+// can be overridden by setting the env var ANDROID_NATIVE_API_LEVEL
+const DEFAULT_ANDROID_API_LEVEL: &'static str = "16";
+
+const OPENAL_SOFT_TAG: &'static str = "openal-soft-1.19.1";
+
+const OPENAL_REPO: &'static str = "https://github.com/kcat/openal-soft.git";
+
+fn clone_openalsoft() -> PathBuf {
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join("openal-soft");
+    let status = Command::new("git")
+        .arg("clone")
+        .args(&["--branch", OPENAL_SOFT_TAG])
+        .args(&["--depth", "1"])
+        .arg(OPENAL_REPO)
+        .arg(&out)
+        .status()
+        .unwrap();
+    if !status.success() {
+        let status = Command::new("git")
+                .arg("clean")
+                .arg("-fdx")
+                .current_dir(&out)
+                .status()
+                .unwrap();
+        assert!(status.success(), "failed to clone openal-soft");
+        let status = Command::new("git")
+                .arg("checkout")
+                .arg(format!("tags/{}", OPENAL_SOFT_TAG))
+                .current_dir(&out)
+                .status()
+                .unwrap();
+        assert!(status.success(), "failed to clone openal-soft");
+    }
+    out
+}
+
+fn build_openalsoft(openal_dir: PathBuf) {
+    let target = &*env::var("TARGET").unwrap();
+    let ndk_dir = &*env::var("NDK_HOME").expect("set the environment variable `NDK_HOME` to the ndk directory to build `al-sys` for android");
+
+    let toolchain_file = PathBuf::from(ndk_dir).join("build/cmake/android.toolchain.cmake");
+    let abi = match target {
+        "aarch64-linux-android" => "arm64-v8a",
+        "armv7-linux-androideabi" => "armeabi-v7a",
+        "arm-linux-androideabi" => "armeabi",
+        "thumbv7neon-linux-androideabi" => "armeabi", // TODO: is this correct?
+        "i686-linux-android" => "x86",
+        "x86_64-linux-android" => "x86_64",
+        _ => unreachable!(),
+    };
+    let libtype = match env::var("CARGO_FEATURE_DYNAMIC") {
+        Ok(_) => "SHARED",
+        _ => "STATIC"
+    };
+    let api_level = env::var("ANDROID_NATIVE_API_LEVEL").unwrap_or(DEFAULT_ANDROID_API_LEVEL.to_owned());
+    let platform = &*format!("android-{}", api_level);
+
+    let dst = Config::new(openal_dir)
+        .define("CMAKE_TOOLCHAIN_FILE", toolchain_file)
+        .define("ANDROID_ABI", abi)
+        .define("ALSOFT_UTILS", "OFF")
+        .define("ALSOFT_EXAMPLES", "OFF")
+        .define("ALSOFT_TESTS", "OFF")
+        .define("ANDROID_NDK", ndk_dir)
+        .define("LIBTYPE", libtype)
+        .define("ANDROID_NATIVE_API_LEVEL", api_level)
+        .define("ANDROID_PLATFORM", platform)
+        .no_build_target(true)
+        .build();
+    println!("cargo:rerun-if-env-changed=ANDROID_NATIVE_API_LEVEL");
+    println!("cargo:rerun-if-env-changed=NDK_HOME");
+    println!("cargo:rustc-link-search=native={}/build", dst.display());
+    println!("cargo:rustc-link-lib=static=common");
+    println!("cargo:rustc-link-lib=static=openal");
+}
+
+fn main() {
+    let target = &*env::var("TARGET").unwrap();
+    match target {
+        "aarch64-linux-android"
+            | "armv7-linux-androideabi"
+            | "arm-linux-androideabi"
+            | "thumbv7neon-linux-androideabi"
+            | "i686-linux-android"
+            | "x86_64-linux-android" => {
+                let repo_path = clone_openalsoft();
+                build_openalsoft(repo_path)
+            },
+        _ => {}
+    }
+}

--- a/al-sys/build.rs
+++ b/al-sys/build.rs
@@ -75,8 +75,13 @@ fn build_openalsoft(openal_dir: PathBuf) {
     println!("cargo:rerun-if-env-changed=ANDROID_NATIVE_API_LEVEL");
     println!("cargo:rerun-if-env-changed=NDK_HOME");
     println!("cargo:rustc-link-search=native={}/build", dst.display());
-    println!("cargo:rustc-link-lib=static=common");
-    println!("cargo:rustc-link-lib=static=openal");
+
+    let link_type = match env::var("CARGO_FEATURE_DYNAMIC") {
+        Ok(_) => "dylib",
+        _ => "static"
+    };
+    println!("cargo:rustc-link-lib={}=common", link_type);
+    println!("cargo:rustc-link-lib={}=openal", link_type);
 }
 
 fn main() {

--- a/al-sys/src/lib.rs
+++ b/al-sys/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(all(not(target_os = "emscripten"), feature = "dynamic"))]
 #[macro_use]
 extern crate rental;
 
@@ -14,7 +14,7 @@ pub use efx::*;
 pub use efx_presets::*;
 
 
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(all(not(target_os = "emscripten"), feature = "dynamic"))]
 macro_rules! al_api {
 	{
 		$($sym:ident: unsafe extern "C" fn ($($param:ident: $param_ty:ty),*) -> $ret_ty:ty,)*
@@ -90,7 +90,7 @@ macro_rules! al_api {
 }
 
 
-#[cfg(target_os = "emscripten")]
+#[cfg(any(target_os = "emscripten", not(feature = "dynamic")))]
 macro_rules! al_api {
 	{
 		$($sym:ident: unsafe extern "C" fn ($($param:ident: $param_ty:ty),*) -> $ret_ty:ty,)*


### PR DESCRIPTION
On platforms like android, openalsoft can be linked to statically or dynamically. This feature flag allows deciding between the "emscripten" style static linking, or dynamic linking (default). Static linking can save a lot of space in the final APK, so android users will likely prefer it.

Currently it is up to the client to figure out how to link statically to the openal implementation. This PR makes no attempt to build openal for android. Though, I may try to add that in the future (once I've worked out the kinks).